### PR TITLE
Add `typing_extensions` runtime dependency to meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   run:
     - python
     - pyarrow >=11.0.0
+    - typing_extensions
 
 test:
   imports:


### PR DESCRIPTION
## This Change

`datafusion-python` requires the runtime dependency `typing_extensions` as of v40.

We updated our own conda recipe that we use to build conda nightlies, but I failed to upstream that change here.

I believe the [v40.1.0 PR](https://github.com/conda-forge/datafusion-feedstock/pull/52) needs to be updated with the change in this PR, then those tests should pass and [v41](https://github.com/conda-forge/datafusion-feedstock/pull/53) can be rebased off that change.

ref: https://github.com/apache/datafusion-python/pull/750

> [!NOTE]
> If you have any suggestions on keeping these two in line, please let me know. Editing the build file in two places seems non-optimal.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Please add any other relevant info below:
